### PR TITLE
Use universally-compatible /usr/bin/python2 rather than /usr/bin/python

### DIFF
--- a/yrd
+++ b/yrd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from subprocess import call, Popen, PIPE, check_output
 from argh import *
 import itertools


### PR DESCRIPTION
A simple tweak to make **yrd** capable of running on all *nix operating systems rather than just _Debian_-based ones
