### PR TITLE
use range instead of python2 exclusive xrange

### DIFF
--- a/yrd/core.py
+++ b/yrd/core.py
@@ -56,7 +56,7 @@ def ping(ip, count=0, switch=False):
 
     ping = c.switchPing if switch else c.routerPing
 
-    for _ in xrange(count) if count else itertools.repeat(None):
+    for _ in range(count) if count else itertools.repeat(None):
         try:
             resp = ping(ip)
         except Exception as e:


### PR DESCRIPTION
This fixes a python3 regression leading to ```NameError: name 'xrange' is not define```