### PR TITLE
fix start command on python 3, force text mode for popen handle

### DIFF
--- a/yrd/start.py
+++ b/yrd/start.py
@@ -13,7 +13,7 @@ def start(attach=False, boot=False):
     'start and/or configure cjdroute'
 
     if not attach:
-        p = Popen(['cjdroute'], stdin=PIPE)
+        p = Popen(['cjdroute'], stdin=PIPE, encoding='UTF-8')
         conf = utils.load_conf(CJDROUTE_CONF, CJDROUTE_BIN)
         p.communicate(json.dumps(conf))
 


### PR DESCRIPTION
In python 3 the default popen handle will communicate via bytes
instead of string/text. Enforce text mode via setting encoding
so communicate happily accepts pure string json without explicit
bytes casting